### PR TITLE
Remove the old widget before rendering new one

### DIFF
--- a/ideogRam.Rproj
+++ b/ideogRam.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 4
 Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes

--- a/inst/htmlwidgets/ideogRam.js
+++ b/inst/htmlwidgets/ideogRam.js
@@ -19,6 +19,11 @@ HTMLWidgets.widget({
               console.log("render");
               console.log(x);
 
+              // Remove the old one
+              // TODO: better approach ?
+              for (var i = 0; i < el.childNodes.length; i++)
+                  el.removeChild(el.childNodes[i]);
+
               // Refer to the shared variable above
               ideogram = new Ideogram(x.data);
 


### PR DESCRIPTION
This is a workaround for the masking chromosome number issue in #2 shiny example, as mentioned in #4 